### PR TITLE
App breaks when opening help

### DIFF
--- a/ScreenRuler/Forms/HelpForm.cs
+++ b/ScreenRuler/Forms/HelpForm.cs
@@ -15,13 +15,8 @@ namespace ScreenRuler
         {
             InitializeComponent();
             this.KeyPreview = true;
-            // Choose right help file.
-            var current = CultureInfo.CurrentUICulture;
-            if (Bluegrams.Application.AppInfo.SupportedCultures
-                    .Where(c => c.TwoLetterISOLanguageName == current.TwoLetterISOLanguageName)
-                    .Count() > 0)
-                lang = current.TwoLetterISOLanguageName;
-            else lang = "en";
+            // Set lang code
+            lang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
         }
 
         private void HelpForm_Load(object sender, EventArgs e)

--- a/ScreenRuler/Forms/HelpForm.cs
+++ b/ScreenRuler/Forms/HelpForm.cs
@@ -15,8 +15,15 @@ namespace ScreenRuler
         {
             InitializeComponent();
             this.KeyPreview = true;
-            // Set lang code
+            // Set lang and check if there is a help file for it.
+            // If not, notify user and fall back to English.
             lang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
+            if (!File.Exists(HelpFileLocation))
+            {
+                var languageName = CultureInfo.CurrentUICulture.DisplayName;
+                MessageBox.Show($"No help file found for {languageName}. Showing English help.", "Language-specific help file not found");
+                lang = "en";
+            }
         }
 
         private void HelpForm_Load(object sender, EventArgs e)

--- a/ScreenRuler/Forms/HelpForm.cs
+++ b/ScreenRuler/Forms/HelpForm.cs
@@ -19,9 +19,7 @@ namespace ScreenRuler
             // If not, fall back to English.
             lang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
             if (!File.Exists(HelpFileLocation))
-            {
                 lang = "en";
-            }
         }
 
         private void HelpForm_Load(object sender, EventArgs e)

--- a/ScreenRuler/Forms/HelpForm.cs
+++ b/ScreenRuler/Forms/HelpForm.cs
@@ -16,12 +16,10 @@ namespace ScreenRuler
             InitializeComponent();
             this.KeyPreview = true;
             // Set lang and check if there is a help file for it.
-            // If not, notify user and fall back to English.
+            // If not, fall back to English.
             lang = CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
             if (!File.Exists(HelpFileLocation))
             {
-                var languageName = CultureInfo.CurrentUICulture.DisplayName;
-                MessageBox.Show($"No help file found for {languageName}. Showing English help.", "Language-specific help file not found");
                 lang = "en";
             }
         }


### PR DESCRIPTION
I happened to notice the help didn't open anymore (for any language) after your latest change to remove SupportedCultures. HelpForm still references the attribute.

Here's my super simple fix if it's acceptable. (I'm a complete c# newbie, my husband helped me fix it based on my solution idea  :)  )